### PR TITLE
Fix CMake code to fix some usage issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(sszpp INTERFACE
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
 	$<INSTALL_INTERFACE:include/sszpp>
 )
-target_link_libraries(sszpp INTERFACE Hashtree::Hashtree)
+target_link_libraries(sszpp INTERFACE Hashtree::Hashtree intx::intx)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ configure_package_config_file(
     INSTALL_DESTINATION lib/cmake/sszpp
 )
 
-install(EXPORT sszppTargets DESTINATION lib/cmake/sszpp)
+install(EXPORT sszppTargets NAMESPACE sszpp:: DESTINATION lib/cmake/sszpp)
 install(FILES "${PROJECT_BINARY_DIR}/sszppConfigVersion.cmake"
               "${PROJECT_BINARY_DIR}/sszppConfig.cmake"
         DESTINATION lib/cmake/sszpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ install(EXPORT sszppTargets NAMESPACE sszpp:: DESTINATION lib/cmake/sszpp)
 install(FILES "${PROJECT_BINARY_DIR}/sszppConfigVersion.cmake"
               "${PROJECT_BINARY_DIR}/sszppConfig.cmake"
         DESTINATION lib/cmake/sszpp)
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/.cmake_modules/" DESTINATION lib/cmake/sszpp)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/lib/ DESTINATION include/sszpp)
 
 option(TIDY "Analyze the code with clang-tidy")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON ) #youcompleteme
 
+option(ENABLE_TESTS "Build tests" ON)
+
 option(CPPCHECK "Analyze the code with cppcheck")
 if(CPPCHECK)
 	message(STATUS "Building with cppcheck")
@@ -71,19 +73,6 @@ install(FILES "${PROJECT_BINARY_DIR}/sszppConfigVersion.cmake"
         DESTINATION lib/cmake/sszpp)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/lib/ DESTINATION include/sszpp)
 
-find_package(yaml-cpp)
-if(NOT yaml-cpp_FOUND)
-    message(STATUS "Didn't find yaml-cpp, will not be able to run spectests")
-else()
-    add_compile_definitions( HAVE_YAML )
-    message(STATUS "Found yaml-cpp")
-endif()
-find_package(Snappy)
-if(NOT Snappy_FOUND)
-    message(STATUS "Didn't find snappy, will not be able to run spectests")
-else() 
-    message(STATUS "Found Snappy")
-endif()
 find_package(Hashtree)
 if(Hashtree_FOUND)
 	message(STATUS "Found Hashtree")
@@ -95,46 +84,62 @@ if(TIDY)
 	set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
 endif()
 
-add_executable( bench_beacon_state 
-                testing/bench_beacon_state.cpp
-            )
-target_link_libraries(bench_beacon_state hashtree)
-add_executable( test_concepts
-                testing/concepts_test.cpp )
-target_link_libraries( test_concepts hashtree)
-add_executable( test_serialize
-                testing/serialize_test.cpp )
-target_link_libraries( test_serialize hashtree)
+if(ENABLE_TESTS)
+    find_package(yaml-cpp)
+    if(NOT yaml-cpp_FOUND)
+        message(STATUS "Didn't find yaml-cpp, will not be able to run spectests")
+    else()
+        add_compile_definitions( HAVE_YAML )
+        message(STATUS "Found yaml-cpp")
+    endif()
+    find_package(Snappy)
+    if(NOT Snappy_FOUND)
+        message(STATUS "Didn't find snappy, will not be able to run spectests")
+    else()
+        message(STATUS "Found Snappy")
+    endif()
 
-if(yaml-cpp_FOUND AND Snappy_FOUND)
-    add_executable( spectests
-                    testing/spec_test.cpp 
+    add_executable( bench_beacon_state
+                    testing/bench_beacon_state.cpp
                 )
-    target_link_libraries(spectests hashtree yaml-cpp snappy )
-    add_test( spectests spectests )
+    target_link_libraries(bench_beacon_state hashtree)
+    add_executable( test_concepts
+                    testing/concepts_test.cpp )
+    target_link_libraries( test_concepts hashtree)
+    add_executable( test_serialize
+                    testing/serialize_test.cpp )
+    target_link_libraries( test_serialize hashtree)
 
-    set( SPECTEST_URL "https://github.com/ethereum/consensus-spec-tests/releases/download")
-    set( SPECTEST_VERSION "v1.4.0-beta.0")
-    set( SPECTEST_MAINNET_HASH "5eeb9b7b0c882fe11ea14444cec44e9e77655f384d80b6743b1f0f82ec9a6599")
+    if(yaml-cpp_FOUND AND Snappy_FOUND)
+        add_executable( spectests
+                        testing/spec_test.cpp
+                    )
+        target_link_libraries(spectests hashtree yaml-cpp snappy )
+        add_test( spectests spectests )
 
-    file (DOWNLOAD "${SPECTEST_URL}/${SPECTEST_VERSION}/mainnet.tar.gz" ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz
-          EXPECTED_HASH SHA256=${SPECTEST_MAINNET_HASH})
+        set( SPECTEST_URL "https://github.com/ethereum/consensus-spec-tests/releases/download")
+        set( SPECTEST_VERSION "v1.4.0-beta.0")
+        set( SPECTEST_MAINNET_HASH "5eeb9b7b0c882fe11ea14444cec44e9e77655f384d80b6743b1f0f82ec9a6599")
 
-    add_custom_target(spec_test_unpack 
-                    DEPENDS ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz)
+        file (DOWNLOAD "${SPECTEST_URL}/${SPECTEST_VERSION}/mainnet.tar.gz" ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz
+            EXPECTED_HASH SHA256=${SPECTEST_MAINNET_HASH})
 
-    add_custom_command(TARGET spec_test_unpack
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tests/mainnet
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    DEPENDS ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz
-    COMMENT "Unpacking mainnet.tar.gz"
-    VERBATIM
-    )
+        add_custom_target(spec_test_unpack
+                        DEPENDS ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz)
 
-    add_dependencies( spectests spec_test_unpack )
+        add_custom_command(TARGET spec_test_unpack
+        COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tests/mainnet
+        COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        DEPENDS ${CMAKE_SOURCE_DIR}/testing/mainnet.tar.gz
+        COMMENT "Unpacking mainnet.tar.gz"
+        VERBATIM
+        )
+
+        add_dependencies( spectests spec_test_unpack )
+    endif()
+
+    enable_testing()
+    add_test( concepts test_concepts )
+    add_test( serialize test_serialize )
 endif()
-                    
-enable_testing()
-add_test( concepts test_concepts )
-add_test( serialize test_serialize )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ target_include_directories(sszpp INTERFACE
 	$<INSTALL_INTERFACE:include/sszpp>
 )
 target_link_libraries(sszpp INTERFACE Hashtree::Hashtree intx::intx)
+target_compile_features(sszpp INTERFACE cxx_std_23)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,14 @@ if(intx_FOUND)
 	message(STATUS "Found intx")
 endif()
 
+find_package(Hashtree MODULE REQUIRED)
+
 add_library(sszpp INTERFACE)
 target_include_directories(sszpp INTERFACE
 	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
 	$<INSTALL_INTERFACE:include/sszpp>
 )
-target_link_libraries(sszpp INTERFACE hashtree)
+target_link_libraries(sszpp INTERFACE Hashtree::Hashtree)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
@@ -73,11 +75,6 @@ install(FILES "${PROJECT_BINARY_DIR}/sszppConfigVersion.cmake"
         DESTINATION lib/cmake/sszpp)
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/lib/ DESTINATION include/sszpp)
 
-find_package(Hashtree)
-if(Hashtree_FOUND)
-	message(STATUS "Found Hashtree")
-endif()
-
 option(TIDY "Analyze the code with clang-tidy")
 if(TIDY)
 	message(STATUS "Building with clang-tidy")
@@ -102,19 +99,19 @@ if(ENABLE_TESTS)
     add_executable( bench_beacon_state
                     testing/bench_beacon_state.cpp
                 )
-    target_link_libraries(bench_beacon_state hashtree)
+    target_link_libraries(bench_beacon_state Hashtree::Hashtree)
     add_executable( test_concepts
                     testing/concepts_test.cpp )
-    target_link_libraries( test_concepts hashtree)
+    target_link_libraries( test_concepts Hashtree::Hashtree)
     add_executable( test_serialize
                     testing/serialize_test.cpp )
-    target_link_libraries( test_serialize hashtree)
+    target_link_libraries( test_serialize Hashtree::Hashtree)
 
     if(yaml-cpp_FOUND AND Snappy_FOUND)
         add_executable( spectests
                         testing/spec_test.cpp
                     )
-        target_link_libraries(spectests hashtree yaml-cpp snappy )
+        target_link_libraries(spectests Hashtree::Hashtree yaml-cpp snappy )
         add_test( spectests spectests )
 
         set( SPECTEST_URL "https://github.com/ethereum/consensus-spec-tests/releases/download")

--- a/cmake/sszppConfig.cmake.in
+++ b/cmake/sszppConfig.cmake.in
@@ -1,5 +1,12 @@
 @PACKAGE_INIT@
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(intx CONFIG REQUIRED)
+find_dependency(Hashtree MODULE REQUIRED)
+
 include("${CMAKE_CURRENT_LIST_DIR}/sszppTargets.cmake")
 check_required_components("@PROJECT_NAME@")
 


### PR DESCRIPTION
I've found some issues with your CMake files, which makes SSZ++ a bit hard to use sometimes. Hope you will have time to look through changes I suggest.

I've separated different parts into different commits for ease of review and gonna provide summary and motivation here.

## 1. Testing configuration

Right now all the testing configs are enabled by default. I think, it would be nice for user to be able to enable/disable testing if needed. Personally I was using your library and I didn't want any tests to be configured. Also because testing requires some additional dependencies and they may produce some warnings, it makes configuration process a bit dirty. That's why I introduced CMake variable `ENABLE_TESTS` to control this. To preserve current behavior, I set it to `ON` by default.

## 2. Linking Hashtree
Linking to `hashtree` was done a bit wrong, I think. Instead of linking to imported target `Hashtree::Hashtree`, which can be brought into scope with `find_package(Hashtree MODULE)`, `sszpp` target was linked to `"hashtree"` library. Because no such target existed, it was treated as a system library. That was causing errors, when `hashtree` was installed to custom location - you could not provide linking paths to it in that case.

## 3. Linking `intx`
`intx` library is used but for some reason was not linked.

## 4. Propagate C++23 compile option
Because SSZ++ is header-only and is using features from C++23, it makes sense to add this option to interface compile options. In that case anyone building code linked to `sszpp`, will have this option set.

## 5. Use namespace for exported target
Using namespace in export as far as I'm aware is considered a better practice, because it avoids confusion with system libraries: `sszpp::sszpp` cannot be a system library in CMake. But notice, that this is a **BREAKING CHANGE**, because after this exported target `sszpp` will be no longer available. User will have to link to `sszpp::sszpp` target instead.

## 6. Check dependencies in config file
Last commit is related to dependency check in CMake config. When bringing SSZ++ library with `find_package` into your project, it would be nice if its dependencies are checked also. This allows a more stable development experience: if one forgot to install one of them, he will be informed about that on configuration, instead of getting a compilation error, which may be confusing.

Hope you will find these changes useful.